### PR TITLE
[Fix]TCGタグのバリデーション修正

### DIFF
--- a/app/models/tcg_genre.rb
+++ b/app/models/tcg_genre.rb
@@ -2,5 +2,5 @@ class TcgGenre < ApplicationRecord
 	belongs_to :user, optional: true
 	belongs_to :tcg_tag, optional: true
 
-	validates :tcg_tag_id, presence: true
+	validates :tcg_tag_id, presence: true, uniqueness: { scope: :user_id }
 end


### PR DESCRIPTION
TcgGenreモデルのuser_idカラムとtcg_tag_idカラムに一意性チェックを設定